### PR TITLE
Add RADON IDE Template library plugin to the devfile.

### DIFF
--- a/devfiles/radon/v0.0.1/devfile.yaml
+++ b/devfiles/radon/v0.0.1/devfile.yaml
@@ -137,4 +137,8 @@ components:
     reference: >-
       https://raw.githubusercontent.com/radon-h2020/radon-plugin-registry/master/radon/radon-menu/latest/meta.yaml
     alias: radon-menu
+  - type: chePlugin
+    reference: >-
+      https://raw.githubusercontent.com/radon-h2020/radon-plugin-registry/master/radon/radon-template-library/latest/meta.yaml
+    alias: radon-template-library-plugin
 apiVersion: 1.0.0


### PR DESCRIPTION
/cc @cankarm, @sstanovnik

Depends on radon-h2020/radon-plugin-registry#4.