### PR TITLE
radon-h2020/radon-ctt#81 Che devfile with CTT parts included.

### DIFF
--- a/devfiles/radon/v0.0.2/devfile.yaml
+++ b/devfiles/radon/v0.0.2/devfile.yaml
@@ -169,6 +169,8 @@ components:
                     value: ""
                   - name: AWS_SECRET_ACCESS_KEY
                     value: ""
+                  - name: KEY_TYPE
+                    value: "<Type of key specified in the header of the SSH private key (e.g., RSA, OPENSSH)>"
                   - name: SSH_PRIV_KEY
                     value: >
                       EC2_SSH_PRIVATE_KEY_WITHOUT_HEADER_AND_FOOTER

--- a/devfiles/radon/v0.0.2/devfile.yaml
+++ b/devfiles/radon/v0.0.2/devfile.yaml
@@ -121,6 +121,62 @@ components:
                     name: projects-storage-vt
     type: kubernetes
     alias: radon-vt
+  - endpoints:
+      - name: radon-ctt
+        port: 18080
+        attributes:
+          protocol: http
+          public: 'true'
+          discoverable: 'false'
+          secure: 'false'
+    referenceContent: |
+      ---
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: ctt-deployment
+        labels:
+          app: ctt
+          tier: frontend
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app: ctt
+            tier: frontend
+        template:
+          metadata:
+            labels:
+              app: ctt
+              tier: frontend
+          spec:
+            volumes:
+              - name: projects-storage-ctt
+                persistentVolumeClaim:
+                  claimName: projects
+            containers:
+              - name: ctt
+                image: radonconsortium/radon-ctt:che
+                imagePullPolicy: Always
+                ports:
+                  - containerPort: 18080
+                env:
+                  - name: OPERA_SSH_USER
+                    value: "ubuntu"
+                  - name: OPERA_SSH_IDENTITY_FILE
+                    value: "/tmp/aws-ec2"
+                  - name: AWS_ACCESS_KEY_ID
+                    value: ""
+                  - name: AWS_SECRET_ACCESS_KEY
+                    value: ""
+                  - name: SSH_PRIV_KEY
+                    value: >
+                      EC2_SSH_PRIVATE_KEY_WITHOUT_HEADER_AND_FOOTER
+                volumeMounts:
+                  - mountPath: "/projects"
+                    name: projects-storage-ctt
+    type: kubernetes
+    alias: radon-ctt   
   - type: chePlugin
     reference: >-
       https://raw.githubusercontent.com/radon-h2020/radon-plugin-registry/master/radon/radon-vt/latest/meta.yaml
@@ -145,4 +201,8 @@ components:
     reference: >-
       https://raw.githubusercontent.com/radon-h2020/radon-plugin-registry/master/radon/radon-template-library/latest/meta.yaml
     alias: radon-template-library-plugin
+  - type: chePlugin
+    reference: >-
+      https://raw.githubusercontent.com/radon-h2020/radon-plugin-registry/master/radon/radon-ctt/latest/meta.yaml
 apiVersion: 1.0.0
+


### PR DESCRIPTION
This PR contains the updated `devfile.yaml` including the CTT Docker container and the plugin reference.

*Please note*: Some parameters need to be filled by the user to properly deploy the test environment.